### PR TITLE
Bump to 0.27.2 and update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@
 |:-------------------:|:--------------:|:------:|:---:|:----:|:---:|
 | **Status:**         |    + <br> (default) | + | +   |   –  |  -  |
 
-[Zplugin](https://github.com/zdharma/zplugin) can use the NPM package registry
-to automatically:
+[Zinit](https://github.com/zdharma/Zinit) can use `package.json` to automatically:
 
 - get the plugin's Git repository OR release-package URL,
 - get the list of the recommended ices for the plugin,
@@ -21,27 +20,27 @@ or from Git repository:
 
 ```zsh
 # Download the package with the default ice list
-zplugin pack for fzf
+zinit pack for fzf
 
 # Download the package with the default ice list + setting up the key bindings
-zplugin pack"default+keys" for fzf
+zinit pack"default+keys" for fzf
 
 # Download the package with the bin-gem-node annex-utilizing ice list
-zplugin pack"bgn" for fzf
+zinit pack"bgn" for fzf
 
 # Download the package with the bin-gem-node annex-utilizing ice list
 # + setting up the key bindings. The "+keys" variants are available
 # for each profile
-zplugin pack"bgn+keys" for fzf
+zinit pack"bgn+keys" for fzf
 
 # Download with the bin-gem-node annex-utilizing ice list FROM GIT REPOSITORY
-zplugin pack"bgn" git for fzf
+zinit pack"bgn" git for fzf
 
 # Download the binary from the Github releases (like from'gh-r' ice)
-zplugin pack"binary" for fzf
+zinit pack"binary" for fzf
 
 # Download the binary from the Github releases and install via Bin-Gem-Node shims
-zplugin pack"bgn-binary" for fzf
+zinit pack"bgn-binary" for fzf
 ```
 
 ## Default Profile
@@ -50,7 +49,7 @@ Provides the fuzzy finder via Makefile-installation of the `fzf` binary under
 `$ZPFX/bin`.
 
 ```zsh
-zplugin lucid as=program pick="$ZPFX/bin/(fzf|fzf-tmux)" \
+zinit lucid as=program pick="$ZPFX/bin/(fzf|fzf-tmux)" \
     atclone="cp shell/completion.zsh _fzf_completion; cp bin/fzf-tmux $ZPFX/bin" \
     make="PREFIX=$ZPFX install" \
     …
@@ -60,10 +59,10 @@ zplugin lucid as=program pick="$ZPFX/bin/(fzf|fzf-tmux)" \
 
 Provides the fuzzy finder via *shims*, i.e.: automatic forwarder scripts created
 under `$ZPFX/bin` (which is added to the `$PATH` by default). It needs the
-[bin-gem-node](https://github.com/zplugin/z-a-bin-gem-node) annex.
+[bin-gem-node](https://github.com/zinit-zsh/z-a-bin-gem-node) annex.
 
 ```zsh
-zplugin lucid as=null make \
+zinit lucid as=null make \
     atclone="cp shell/completion.zsh _fzf_completion" \
     sbin="fzf;bin/fzf-tmux" \
     …

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@
     - the ice lists are stored in *profiles*; there's at least one profile, *default*,
     - the ices can be selectively overriden.
 
+More documentation on Zinit Packages can be 
+found on the [Zinit Wiki](https://zdharma.github.io/zinit/wiki/Zinit-Packages/).
+
 Example invocations that'll install
 [junegunn/fzf](https://github.com/junegunn/fzf) either from the release archive
 or from Git repository:

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
             },
             "binary": {
                 "requires": "cp",
-                "plugin": "fzf-bin",
+                "plugin": "fzf",
                 "from": "gh-r",
                 "lucid": "",
                 "as": "command",
@@ -111,7 +111,7 @@
             },
             "binary+keys": {
                 "requires": "cp;dl",
-                "plugin": "fzf-bin",
+                "plugin": "fzf",
                 "from": "gh-r",
                 "lucid": "",
                 "as": "command",
@@ -124,7 +124,7 @@
             },
             "bgn-binary": {
                 "requires": "cp;bgn",
-                "plugin": "fzf-bin",
+                "plugin": "fzf",
                 "from": "gh-r",
                 "lucid": "",
                 "pick": "/dev/null",
@@ -136,7 +136,7 @@
             },
             "bgn-binary+keys": {
                 "requires": "cp;bgn;dl",
-                "plugin": "fzf-bin",
+                "plugin": "fzf",
                 "from": "gh-r",
                 "lucid": "",
                 "pick": "/dev/null",

--- a/package.json
+++ b/package.json
@@ -1,23 +1,23 @@
 {
-    "_from": "fzf@^0.24.2",
-    "_id": "zsh-fzf@0.24.2",
+    "_from": "fzf@^0.27.2",
+    "_id": "zsh-fzf@0.27.2",
     "_inBundle": false,
     "_location": "/zsh-fzf",
     "_phantomChildren": {},
     "_requested": {
         "type": "range",
         "registry": true,
-        "raw": "fzf@^0.24.2",
+        "raw": "fzf@^0.27.2",
         "name": "fzf",
         "escapedName": "fzf",
-        "rawSpec": "^0.24.2",
+        "rawSpec": "^0.27.2",
         "saveSpec": null,
-        "fetchSpec": "^0.24.2"
+        "fetchSpec": "^0.27.2"
     },
     "_requiredBy": [],
-    "_resolved": "https://github.com/junegunn/fzf/archive/0.24.2.tar.gz",
-    "_shasum": "a3d59760bd74671499a3db5d05d57f25ebae75f4",
-    "_spec": "fzf@^0.24.2",
+    "_resolved": "https://github.com/junegunn/fzf/archive/0.27.2.tar.gz",
+    "_shasum": "1bf77b90cb3d8ea3188d8a0832fa05aa07f0485d",
+    "_spec": "fzf@^0.27.2",
     "_where": "/root/github2/pkg-fzf",
     "author": "Junegunn Choi",
     "bugs": {
@@ -43,12 +43,12 @@
     "scripts": {
         "test": "make test"
     },
-    "version": "0.24.2",
+    "version": "0.27.2",
     "zsh-data": {
         "plugin-info": {
             "user": "junegunn",
             "plugin": "fzf",
-            "version": "0.24.2"
+            "version": "0.27.2"
         },
         "zplugin-ices": {
             "default": {


### PR DESCRIPTION
Hi all,
I noticed that the version of fzf used by this zinit package was out of date. I made some quick edits to the package file to point towards the latest version of fzf.

Additionally the README file didn't seem to be up to date and made the following edits.
- Change usage of Zplugin to Zinit.
- Correct outdated links to point to current location of pages.
- Replace mention of NPM with intro blurb from Zsh Zinit package.
- Add link to wiki page on the Zinit Packages.